### PR TITLE
fix: remove error return on method new

### DIFF
--- a/service/slack/slack.go
+++ b/service/slack/slack.go
@@ -14,7 +14,7 @@ type Slack struct {
 // New returns a new instance of a Slack notification service.
 // For more information about slack api token:
 //    -> https://pkg.go.dev/github.com/slack-go/slack#New
-func New(apiToken string) (*Slack, error) {
+func New(apiToken string) *Slack {
 	client := slack.New(apiToken)
 
 	s := &Slack{
@@ -22,7 +22,7 @@ func New(apiToken string) (*Slack, error) {
 		channelIDs: []string{},
 	}
 
-	return s, nil
+	return s
 }
 
 // AddReceivers takes Slack channel IDs and adds them to the internal channel ID list. The Send method will send


### PR DESCRIPTION
it was removed because it wasn't used.

