### PR TITLE
refactor(notifier): Simplify notify.Notifier interface

### DIFF
--- a/notifier.go
+++ b/notifier.go
@@ -1,14 +1,9 @@
 package notify
 
-// Notifier defines the behavior for notification services. It implements Send and AddReciever
+// Notifier defines the behavior for notification services.
 //
-// The Send command simply sends a message string to the internal destination Notifier.
-//  E.g for telegram it sends the message to the specified group chat.
-//
-// The AddReceivers takes one or many strings and
-// adds these to the list of destinations for receiving messages
-// e.g. slack channels, telegram chats, email addresses.
+// The Send function simply sends a subject and a message string to the internal destination Notifier.
+//  E.g for telegram.Telegram it sends the message to the specified group chat.
 type Notifier interface {
 	Send(string, string) error
-	AddReceivers(...string)
 }

--- a/notify.go
+++ b/notify.go
@@ -18,7 +18,7 @@ type Notify struct {
 // ErrSendNotification signals that the notifier failed to send a notification.
 var ErrSendNotification = errors.New("send notification")
 
-// New returns a new instance of Notify. Defaulting to being not disabled
+// New returns a new instance of Notify. Defaulting to being not disabled.
 func New() *Notify {
 	notifier := &Notify{
 		Disabled:  defaultDisabled,

--- a/send.go
+++ b/send.go
@@ -5,7 +5,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// Send calls the underlying notification services to send the given message to their respective endpoints.
+// Send calls the underlying notification services to send the given subject and message to their respective endpoints.
 func (n Notify) Send(subject, message string) error {
 	if n.Disabled {
 		return nil

--- a/service/telegram/telegram.go
+++ b/service/telegram/telegram.go
@@ -1,8 +1,6 @@
 package telegram
 
 import (
-	"strconv"
-
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/pkg/errors"
 )
@@ -34,13 +32,8 @@ func New(apiToken string) (*Telegram, error) {
 
 // AddReceivers takes Telegram chat IDs and adds them to the internal chat ID list. The Send method will send
 // a given message to all those chats.
-func (t *Telegram) AddReceivers(chatIDs ...string) {
-	for _, v := range chatIDs {
-		chatID, err := strconv.ParseInt(v, 10, 64)
-		if err == nil {
-			t.chatIDs = append(t.chatIDs, chatID)
-		}
-	}
+func (t *Telegram) AddReceivers(chatIDs ...int64) {
+	t.chatIDs = append(t.chatIDs, chatIDs...)
 }
 
 // Send takes a message subject and a message body and sends them to all previously set chats. Message body supports

--- a/use.go
+++ b/use.go
@@ -1,6 +1,6 @@
 package notify
 
-// useService adds a given service to the notifiers services list.
+// useService adds a given service to the Notifier's services list.
 func (n *Notify) useService(service Notifier) {
 	if service == nil {
 		return
@@ -8,7 +8,7 @@ func (n *Notify) useService(service Notifier) {
 	n.notifiers = append(n.notifiers, service)
 }
 
-// UseServices adds the given service(s) to the notifiers services list.
+// UseServices adds the given service(s) to the Notifier's services list.
 func (n *Notify) UseServices(service ...Notifier) {
 	for _, s := range service {
 		n.useService(s)

--- a/use.go
+++ b/use.go
@@ -2,10 +2,9 @@ package notify
 
 // useService adds a given service to the Notifier's services list.
 func (n *Notify) useService(service Notifier) {
-	if service == nil {
-		return
+	if service != nil {
+		n.notifiers = append(n.notifiers, service)
 	}
-	n.notifiers = append(n.notifiers, service)
 }
 
 // UseServices adds the given service(s) to the Notifier's services list.


### PR DESCRIPTION
## Info

_AddReceivers_ is an unnecessary part of the _notify.Notifier_ interface. It is not used once in the code in direct reference to the interface, but only by the services structs themselves.

Read bd82278932b6a5c950de057d5098f695360c0ba9 and ecdfb6f1cf64ff751d7249c66bd5cd74570b7d58 for more details.

## Proposed changes

- Remove _AddReceivers_ function from notify.Notifier interface
- Simplify _telegram.AddReceivers_ internals and make it accept variadic int64 array again
- Simplify _notify.Use_ function
- Update some comments
