### PR TITLE
docs: Minor update for slack usage doc

### DIFF
--- a/service/slack/usage.md
+++ b/service/slack/usage.md
@@ -42,12 +42,14 @@ func main() {
 
     // Send a message
     _ = notifier.Send(
+        context.Background(),
         "Hello :wave:\n",
         "I am a bot written in Go!",
     )
 
     // Code isn't working and need to debug? Use this code below:
     // x := notifier.Send(
+    //  context.Background(),
     //  "Hello :wave:\n",
     //  "I am a bot written in Go!",
     // )


### PR DESCRIPTION
Just added the now required context when using `notifier.Send()` to the slack usage docs. Thanks!