### PR TITLE
feat(notify): add NewWithServices() constructor function

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ _ = notify.Send(
 )
 ```
 
+#### Recommendation <a id="recommendation"></a>
+
+In this example, we use the global `Send()` function. Similar to most logging libraries such as
+[zap](https://github.com/uber-go/zap), we provide global functions for convenience. However, as with most logging
+libraries, we also recommend avoiding the use of global functions as much as possible. Instead, use one of our versatile
+constructor functions to create a new local `Notify` instance and pass it down the stream.
+
+Read the [library docs](https://pkg.go.dev/github.com/nikoksr/notify) for more information.
+
 ## Contributing <a id="contributing"></a>
 
 Yes, please! Contributions of all kinds are very welcome! Feel free to check our [open issues](https://github.com/nikoksr/notify/issues). Please also take a look at the [contribution guidelines](https://github.com/nikoksr/notify/blob/main/CONTRIBUTING.md).

--- a/notify.go
+++ b/notify.go
@@ -66,6 +66,15 @@ func New() *Notify {
 	return NewWithOptions()
 }
 
+// NewWithServices returns a new instance of Notify with the given services. By default, the Notify instance is enabled.
+// If no services are provided, it returns a new Notify instance with default options.
+func NewWithServices(services ...Notifier) *Notify {
+	n := New()
+	n.UseServices(services...)
+
+	return n
+}
+
 // Create the package level Notify instance.
 var std = New()
 

--- a/notify_test.go
+++ b/notify_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/nikoksr/notify/service/mail"
 )
 
 func TestNew(t *testing.T) {
@@ -62,5 +64,36 @@ func TestDefault(t *testing.T) {
 	// Compare addresses on purpose.
 	if n != std {
 		t.Error("Default() did not return the default Notifier")
+	}
+}
+
+func TestNewWithServices(t *testing.T) {
+	t.Parallel()
+
+	n1 := NewWithServices()
+	if n1 == nil {
+		t.Fatal("NewWithServices() returned nil")
+	}
+
+	n2 := NewWithServices(nil)
+	if n2 == nil {
+		t.Fatal("NewWithServices(nil) returned nil")
+	}
+	if len(n2.notifiers) != 0 {
+		t.Error("NewWithServices(nil) did not return empty Notifier")
+	}
+
+	mailService := mail.New("", "")
+	n3 := NewWithServices(mailService)
+	if n3 == nil {
+		t.Fatal("NewWithServices(mail.New()) returned nil")
+	}
+	if len(n3.notifiers) != 1 {
+		t.Errorf("NewWithServices(mail.New()) was expected to have 1 notifier but had %d", len(n3.notifiers))
+	} else {
+		diff := cmp.Diff(n3.notifiers[0], mailService, cmp.AllowUnexported(mail.Mail{}))
+		if diff != "" {
+			t.Errorf("NewWithServices(mail.New()) did not correctly use service:\n%s", diff)
+		}
 	}
 }

--- a/use.go
+++ b/use.go
@@ -8,18 +8,18 @@ func (n *Notify) useService(service Notifier) {
 }
 
 // useServices adds the given service(s) to the Notifier's services list.
-func (n *Notify) useServices(service ...Notifier) {
-	for _, s := range service {
+func (n *Notify) useServices(services ...Notifier) {
+	for _, s := range services {
 		n.useService(s)
 	}
 }
 
 // UseServices adds the given service(s) to the Notifier's services list.
-func (n *Notify) UseServices(service ...Notifier) {
-	n.useServices(service...)
+func (n *Notify) UseServices(services ...Notifier) {
+	n.useServices(services...)
 }
 
 // UseServices adds the given service(s) to the Notifier's services list.
-func UseServices(service ...Notifier) {
-	std.UseServices(service...)
+func UseServices(services ...Notifier) {
+	std.UseServices(services...)
 }


### PR DESCRIPTION
## Description
`NewWithServices()` accepts a variadic list of services and returns a new, by `New()` created, `Notify` instance with the list of services set as its notifiers.

If no services are given it's the functionally identical to just calling `New()` directly. Calling `NewWithServices()` with a list of services is functionally equal to calling `New()` and then `UseServices()`.

## Motivation and Context

A small convenience construcor that potentially saves one or more additional function calls.

## How Has This Been Tested?

Added tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!--- Credit: https://github.com/orhun/git-cliff/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
