### PR TITLE
fix(lint): export types that are being returned by some methods

### DIFF
--- a/service/lark/common.go
+++ b/service/lark/common.go
@@ -10,35 +10,35 @@ type sendToer interface {
 	SendTo(subject, message, id, idType string) error
 }
 
-// receiverID encapsulates a receiver ID and its type in Lark.
-type receiverID struct {
+// ReceiverID encapsulates a receiver ID and its type in Lark.
+type ReceiverID struct {
 	id  string
 	typ receiverIDType
 }
 
 // OpenID specifies an ID as a Lark Open ID.
-func OpenID(s string) *receiverID {
-	return &receiverID{s, openID}
+func OpenID(s string) *ReceiverID {
+	return &ReceiverID{s, openID}
 }
 
 // UserID specifies an ID as a Lark User ID.
-func UserID(s string) *receiverID {
-	return &receiverID{s, userID}
+func UserID(s string) *ReceiverID {
+	return &ReceiverID{s, userID}
 }
 
 // UnionID specifies an ID as a Lark Union ID.
-func UnionID(s string) *receiverID {
-	return &receiverID{s, unionID}
+func UnionID(s string) *ReceiverID {
+	return &ReceiverID{s, unionID}
 }
 
 // Email specifies a receiver ID as an email.
-func Email(s string) *receiverID {
-	return &receiverID{s, email}
+func Email(s string) *ReceiverID {
+	return &ReceiverID{s, email}
 }
 
 // ChatID specifies an ID as a Lark Chat ID.
-func ChatID(s string) *receiverID {
-	return &receiverID{s, chatID}
+func ChatID(s string) *ReceiverID {
+	return &ReceiverID{s, chatID}
 }
 
 // receiverIDType represents the different ID types implemented by Lark. This

--- a/service/lark/custom_app.go
+++ b/service/lark/custom_app.go
@@ -11,17 +11,18 @@ import (
 	"github.com/nikoksr/notify"
 )
 
-type customAppService struct {
-	receiveIDs []*receiverID
+// CustomAppService is a Lark notify service using a Lark custom app.
+type CustomAppService struct {
+	receiveIDs []*ReceiverID
 	cli        sendToer
 }
 
 // Compile time check that larkCustomAppService implements notify.Notifer.
-var _ notify.Notifier = &customAppService{}
+var _ notify.Notifier = &CustomAppService{}
 
 // NewCustomAppService returns a new instance of a Lark notify service using a
 // Lark custom app.
-func NewCustomAppService(appID, appSecret string) *customAppService {
+func NewCustomAppService(appID, appSecret string) *CustomAppService {
 	bot := lark.NewChatBot(appID, appSecret)
 
 	// We need to set the bot to use Lark's open.larksuite.com domain instead of
@@ -36,8 +37,8 @@ func NewCustomAppService(appID, appSecret string) *customAppService {
 
 	_ = bot.StartHeartbeat()
 
-	return &customAppService{
-		receiveIDs: make([]*receiverID, 0),
+	return &CustomAppService{
+		receiveIDs: make([]*ReceiverID, 0),
 		cli: &larkClientGoLarkChatBot{
 			bot: bot,
 		},
@@ -55,13 +56,13 @@ func NewCustomAppService(appID, appSecret string) *customAppService {
 //	  lark.Email("xyz@example.com"),
 //	  lark.ChatID("oc_a0553eda9014c201e6969b478895c230"),
 //	)
-func (c *customAppService) AddReceivers(ids ...*receiverID) {
+func (c *CustomAppService) AddReceivers(ids ...*ReceiverID) {
 	c.receiveIDs = append(c.receiveIDs, ids...)
 }
 
 // Send takes a message subject and a message body and sends them to all
 // previously registered recipient IDs.
-func (c *customAppService) Send(ctx context.Context, subject, message string) error {
+func (c *CustomAppService) Send(ctx context.Context, subject, message string) error {
 	for _, id := range c.receiveIDs {
 		select {
 		case <-ctx.Done():

--- a/service/lark/custom_app_test.go
+++ b/service/lark/custom_app_test.go
@@ -11,7 +11,7 @@ import (
 func TestAddReceivers(t *testing.T) {
 	t.Parallel()
 
-	xs := []*receiverID{
+	xs := []*ReceiverID{
 		OpenID("ou_c99c5f35d542efc7ee492afe11af19ef"),
 		UserID("8335aga2"),
 	}
@@ -21,7 +21,7 @@ func TestAddReceivers(t *testing.T) {
 	assert.ElementsMatch(t, svc.receiveIDs, xs)
 
 	// Test if adding more receivers afterwards works.
-	ys := []*receiverID{
+	ys := []*ReceiverID{
 		UnionID("on_cad4860e7af114fb4ff6c5d496d1dd76"),
 		Email("xyz@example.com"),
 		ChatID("oc_a0553eda9014c201e6969b478895c230"),
@@ -36,7 +36,7 @@ func TestSendCustomApp(t *testing.T) {
 	ctx := context.Background()
 	assert := assert.New(t)
 
-	tests := []*receiverID{
+	tests := []*ReceiverID{
 		OpenID("ou_c99c5f35d542efc7ee492afe11af19ef"),
 		UserID("8335aga2"),
 		UnionID("on_cad4860e7af114fb4ff6c5d496d1dd76"),

--- a/service/lark/webhook.go
+++ b/service/lark/webhook.go
@@ -9,20 +9,21 @@ import (
 	"github.com/nikoksr/notify"
 )
 
-type webhookService struct {
+// WebhookService is a Notify service that uses a Lark webhook to send messages.
+type WebhookService struct {
 	cli sender
 }
 
 // Compile time check that larkCustomAppService implements notify.Notifer.
-var _ notify.Notifier = &webhookService{}
+var _ notify.Notifier = &WebhookService{}
 
 // NewWebhookService returns a new instance of a Lark notify service using a
 // Lark group chat webhook. Note that this service does not take any
 // notification receivers because it can only push messages to the group chat
 // it belongs to.
-func NewWebhookService(webhookURL string) *webhookService {
+func NewWebhookService(webhookURL string) *WebhookService {
 	bot := lark.NewNotificationBot(webhookURL)
-	return &webhookService{
+	return &WebhookService{
 		cli: &larkClientGoLarkNotificationBot{
 			bot: bot,
 		},
@@ -30,7 +31,7 @@ func NewWebhookService(webhookURL string) *webhookService {
 }
 
 // Send sends the message subject and body to the group chat.
-func (w *webhookService) Send(ctx context.Context, subject, message string) error {
+func (w *WebhookService) Send(ctx context.Context, subject, message string) error {
 	return w.cli.Send(subject, message)
 }
 


### PR DESCRIPTION
## Description

The revive linter complained about certain types that were not exported but being used as return values by certain methods. I exported these types now and added the missing comments for them.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

GitHub pipeline was stuck due to the linter complaining about this issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran the linter and test suit locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!--- Credit: https://github.com/orhun/git-cliff/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
