### PR TITLE
ci(release): add nightly release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,27 @@
+name: Deploy Nightly
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * *' # Run every day at 0 AM UTC
+
+jobs:
+  nightly:
+    name: Deploy Nightly
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Get current date
+        id: get_date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Create nightly release
+        id: create_release
+        uses: viperproject/create-nightly-release@v1
+        with:
+          tag_name: nightly
+          release_name: Nightly - ${{ steps.get_date.outputs.date }}
+          keep_num: 0
+          keep_tags: false


### PR DESCRIPTION
## Description

Add a GitHub action that every night at `0:00 UTC` creates a nightly release of Notify.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since `renovatebot` constantly updates dependencies of Notify and merges them into main, it semed sensible to add a nightly release. This ensures that Notify is always up to date, so users who need to rely on the latest changes do not have to wait for a manual release.

@svaloumas adding this as previously discussed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran the action locally with [act](https://github.com/nektos/act).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other <!--- (provide information) --> CI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!--- Credit: https://github.com/orhun/git-cliff/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
