### PR TITLE
ci(nightly): explicitly remove previous nightly release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,11 +1,11 @@
 name: Deploy Nightly
 
 on:
+  schedule:
+    - cron: "0 0 * * *" # Run at 00:00 UTC every day
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 0 * * *' # Run every day at 0 AM UTC
 
 jobs:
   nightly:
@@ -13,15 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG_NAME: nightly
     steps:
       - name: Get current date
         id: get_date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-      - name: Create nightly release
+      - name: Remove old nightly release
+        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        with:
+          delete_release: true
+          tag_name: ${{ env.TAG_NAME }}
+      - name: Create new nightly release
         id: create_release
         uses: viperproject/create-nightly-release@v1
         with:
-          tag_name: nightly
+          tag_name: ${{ env.TAG_NAME }}
           release_name: Nightly - ${{ steps.get_date.outputs.date }}
           keep_num: 0
           keep_tags: false


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Explicitly remove the previous `nightly` release before creating the new one.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I expected the action that creates the nightly release to also remove the old release. It has options for keeping old releases etc but appararently it's none of its business. Thus, we're now explicitly removing the 'nightly' tag before re-creating it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran `act` locally and it successfully removed the old tag and created the new release, all in remote.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other <!--- (provide information) --> CI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x All new and existing tests passed.


<!--- Credit: https://github.com/orhun/git-cliff/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
