### PR TITLE
ci(renovate): add additional assignee and post-run gomodtidy to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,17 @@
 {
-    "assignees": ["nikoksr"],
-    "labels": ["type/deps"],
     "extends": [
         "config:base"
     ],
+    "assignees": ["nikoksr", "svaloumas"],
+    "labels": ["type/deps"],
     "packageRules": [
         {
             "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
             "automerge": true
         }
+    ],
+    "postUpdateOptions": [
+        "gomodTidy"
     ],
     "dependencyDashboard": false
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Adding @svaloumas to list of assignees for potential issues that renovate may encounter and adding `go mod tidy` as post-update operation. From now, after updating a dependency, renovate should also execute `go mod tidy` against the repo once.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Cleaner gomod files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Output (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other: CI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!--- Credit: https://github.com/orhun/git-cliff/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
