### PR TITLE
test(fix): Fix sporadic whatsapp service test fails

### DIFF
--- a/service/whatsapp/whatsapp.go
+++ b/service/whatsapp/whatsapp.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	qrLoginWaitTime = 3 * time.Second
-	clientTimeout   = 5 * time.Second
+	qrLoginWaitTime = 10 * time.Second
+	clientTimeout   = 30 * time.Second
 )
 
 var sessionFilePath = filepath.Join(os.TempDir(), "whatsappSession.gob")

--- a/service/whatsapp/whatsapp_test.go
+++ b/service/whatsapp/whatsapp_test.go
@@ -15,8 +15,8 @@ func TestWhatsApp_New(t *testing.T) {
 	assert := require.New(t)
 
 	service, err := New()
-	assert.NotNil(service)
 	assert.Nil(err)
+	assert.NotNil(service)
 }
 
 func TestWhatsApp_AddReceivers(t *testing.T) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Increase the connectivity timeouts for the WhatsApp service and change the order of execution for some assertments in the testfile.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We're currently experiencing a bug in our CI where the whatsapp.New method fails inconsistently. The bug is not reproducible on a local machine, so I'm guessing here that too short timeouts may be the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Difficult to test since bug only occurs in GitHub's CI. I was so far not successful in reproducing it locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!--- Credit: https://github.com/orhun/git-cliff/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
