### PR TITLE
chore(lint): use blank identifier for context

### DIFF
--- a/service/lark/webhook.go
+++ b/service/lark/webhook.go
@@ -31,7 +31,7 @@ func NewWebhookService(webhookURL string) *WebhookService {
 }
 
 // Send sends the message subject and body to the group chat.
-func (w *WebhookService) Send(ctx context.Context, subject, message string) error {
+func (w *WebhookService) Send(_ context.Context, subject, message string) error {
 	return w.cli.Send(subject, message)
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Sets an unused `ctx context.Context` in `lark's` `WebhookService.Send` method to a blank identifier.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes the linter complaint as seen [here](https://github.com/nikoksr/notify/actions/runs/4485238493/jobs/7886584514) for example. We're not removing the context parameter from the method as it keeps the method signature consistent with the rest of the codebase.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran linter locally, no more complaints. Test suite passes as well.

## Screenshots / Output (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!--- Credit: https://github.com/orhun/git-cliff/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
