### PR TITLE
allow to send html emails on mailgun

### DIFF
--- a/service/mailgun/mailgun.go
+++ b/service/mailgun/mailgun.go
@@ -7,12 +7,20 @@ import (
 	"github.com/mailgun/mailgun-go/v5"
 )
 
+type mailgunMode int
+
+const (
+	mailgunModeText mailgunMode = iota
+	mailgunModeHTML
+)
+
 // Mailgun struct holds necessary data to communicate with the Mailgun API.
 type Mailgun struct {
 	client            *mailgun.Client
 	domain            string
 	senderAddress     string
 	receiverAddresses []string
+	mode              mailgunMode
 }
 
 // New returns a new instance of a Mailgun notification service.
@@ -24,6 +32,7 @@ func New(domain, apiKey, senderAddress string, opts ...Option) *Mailgun {
 		domain:            domain,
 		senderAddress:     senderAddress,
 		receiverAddresses: []string{},
+		mode:              mailgunModeText,
 	}
 
 	for _, opt := range opts {
@@ -42,7 +51,16 @@ func (m *Mailgun) AddReceivers(addresses ...string) {
 // Send takes a message subject and a message body and sends them to all previously set chats. Message body supports
 // html as markup language.
 func (m Mailgun) Send(ctx context.Context, subject, message string) error {
-	mailMessage := mailgun.NewMessage(m.domain, m.senderAddress, subject, message, m.receiverAddresses...)
+	var mailMessage *mailgun.PlainMessage
+	switch m.mode {
+	case mailgunModeText:
+		mailMessage = mailgun.NewMessage(m.domain, m.senderAddress, subject, message, m.receiverAddresses...)
+	case mailgunModeHTML:
+		mailMessage = mailgun.NewMessage(m.domain, m.senderAddress, subject, "", m.receiverAddresses...)
+		mailMessage.SetHTML(message)
+	default:
+		return fmt.Errorf("unknown mailgun mode: %d", m.mode)
+	}
 
 	_, err := m.client.Send(ctx, mailMessage)
 	if err != nil {

--- a/service/mailgun/mailgun.go
+++ b/service/mailgun/mailgun.go
@@ -48,8 +48,8 @@ func (m *Mailgun) AddReceivers(addresses ...string) {
 	m.receiverAddresses = append(m.receiverAddresses, addresses...)
 }
 
-// Send takes a message subject and a message body and sends them to all previously set chats. Message body supports
-// html as markup language.
+// Send takes a message subject and a message body and sends them to all previously added email receivers.
+// The body is sent as plain text by default, or as HTML when the service is configured with WithHTML().
 func (m Mailgun) Send(ctx context.Context, subject, message string) error {
 	var mailMessage *mailgun.PlainMessage
 	switch m.mode {

--- a/service/mailgun/options.go
+++ b/service/mailgun/options.go
@@ -13,3 +13,9 @@ func WithEurope() Option {
 		_ = m.client.SetAPIBase(mailgun.APIBaseEU)
 	}
 }
+
+func WithHTML() Option {
+	return func(m *Mailgun) {
+		m.mode = mailgunModeHTML
+	}
+}

--- a/service/mailgun/options.go
+++ b/service/mailgun/options.go
@@ -14,6 +14,7 @@ func WithEurope() Option {
 	}
 }
 
+// WithHTML sets the message mode to HTML. By default, the message mode is text.
 func WithHTML() Option {
 	return func(m *Mailgun) {
 		m.mode = mailgunModeHTML


### PR DESCRIPTION
## Description
This changes allows to send HTML emails with the mailgun provider. Currently all emails are hardcoded to plain text emails.

## Motivation and Context
I want to send HTML emails using the mailgun provider

## How Has This Been Tested?
locally

## Screenshots / Output (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!--- Credit: https://github.com/orhun/git-cliff/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
