### PR TITLE
feat(bark): add optional AES-GCM encryption

### DIFF
--- a/service/bark/README.md
+++ b/service/bark/README.md
@@ -15,6 +15,11 @@ barkService = bark.New("your bark device key")
 // Add more servers
 barkService.AddReceivers("https://your-bark-server.com")
 
+// Optional: use the encryption key configured in the Bark app.
+if err := barkService.SetEncryptionKey("1234567890123456"); err != nil {
+    log.Fatal(err)
+}
+
 // Tell our notifier to use the bark service.
 notify.UseServices(barkService)
 
@@ -26,3 +31,5 @@ _ = notify.Send(
 )
 ```
 
+See [SetEncryptionKey](https://pkg.go.dev/github.com/nikoksr/notify/service/bark#Service.SetEncryptionKey)
+for key requirements and configuration behavior.

--- a/service/bark/bark.go
+++ b/service/bark/bark.go
@@ -125,23 +125,16 @@ func (s *Service) SetEncryptionKey(key string) error {
 	return nil
 }
 
-// notificationParams is the Bark parameter object encrypted inside ciphertext.
-// device_key stays on the outer request.
-type notificationParams struct {
-	Title string `json:"title"`
-	Body  string `json:"body,omitempty"`
-	Badge int    `json:"badge,omitzero"`
-	Sound string `json:"sound,omitempty"`
-	Icon  string `json:"icon,omitempty"`
-	Group string `json:"group,omitempty"`
-	URL   string `json:"pushURL,omitempty"`
-}
-
-// postData is the plaintext Bark /push request.
+// postData is the data to send to the bark server.
 type postData struct {
-	notificationParams
-
 	DeviceKey string `json:"device_key"`
+	Title     string `json:"title"`
+	Body      string `json:"body,omitempty"`
+	Badge     int    `json:"badge,omitempty"`
+	Sound     string `json:"sound,omitempty"`
+	Icon      string `json:"icon,omitempty"`
+	Group     string `json:"group,omitempty"`
+	URL       string `json:"pushURL,omitempty"`
 }
 
 // encryptedPostData is the Bark /push wire format used when AES-GCM is enabled.
@@ -156,9 +149,24 @@ func (s *Service) send(ctx context.Context, serverURL, subject, content string) 
 		return errors.New("server url is empty")
 	}
 
-	messageJSON, err := s.marshalRequest(subject, content)
+	// Marshal the message to post
+	message := &postData{
+		DeviceKey: s.deviceKey,
+		Title:     subject,
+		Body:      content,
+		Sound:     "alarm.caf",
+	}
+
+	messageJSON, err := json.Marshal(message)
 	if err != nil {
-		return err
+		return fmt.Errorf("marshal message: %w", err)
+	}
+
+	if len(s.encryptionKey) != 0 {
+		messageJSON, err = s.encryptMessage(message)
+		if err != nil {
+			return fmt.Errorf("encrypt payload: %w", err)
+		}
 	}
 
 	pushURL := serverURL + "push"
@@ -191,26 +199,17 @@ func (s *Service) send(ctx context.Context, serverURL, subject, content string) 
 	return nil
 }
 
-func (s *Service) marshalRequest(subject, content string) ([]byte, error) {
-	params := notificationParams{
-		Title: subject,
-		Body:  content,
-		Sound: "alarm.caf",
-	}
-
-	if len(s.encryptionKey) == 0 {
-		messageJSON, err := json.Marshal(&postData{
-			DeviceKey:          s.deviceKey,
-			notificationParams: params,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("marshal message: %w", err)
-		}
-
-		return messageJSON, nil
-	}
-
-	plaintext, err := json.Marshal(&params)
+func (s *Service) encryptMessage(message *postData) ([]byte, error) {
+	// Encrypt the notification fields populated by Send; device_key stays outside.
+	plaintext, err := json.Marshal(struct {
+		Title string `json:"title"`
+		Body  string `json:"body,omitempty"`
+		Sound string `json:"sound,omitempty"`
+	}{
+		Title: message.Title,
+		Body:  message.Body,
+		Sound: message.Sound,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal plaintext message: %w", err)
 	}
@@ -224,7 +223,7 @@ func (s *Service) marshalRequest(subject, content string) ([]byte, error) {
 
 	ciphertext, err := encryptBytes(s.encryptionKey, iv, plaintext)
 	if err != nil {
-		return nil, fmt.Errorf("encrypt payload: %w", err)
+		return nil, err
 	}
 
 	encrypted := &encryptedPostData{

--- a/service/bark/bark.go
+++ b/service/bark/bark.go
@@ -108,8 +108,10 @@ func (s *Service) SetEncryptionKey(key string) error {
 		return nil
 	}
 
-	if !isASCII(key) {
-		return errors.New("bark encryption key must contain only ASCII characters")
+	for _, r := range key {
+		if r > unicode.MaxASCII {
+			return errors.New("bark encryption key must contain only ASCII characters")
+		}
 	}
 
 	switch len(key) {
@@ -121,16 +123,6 @@ func (s *Service) SetEncryptionKey(key string) error {
 	s.encryptionKey = []byte(key)
 
 	return nil
-}
-
-func isASCII(value string) bool {
-	for _, r := range value {
-		if r > unicode.MaxASCII {
-			return false
-		}
-	}
-
-	return true
 }
 
 // notificationParams is the Bark parameter object encrypted inside ciphertext.
@@ -223,7 +215,13 @@ func (s *Service) marshalRequest(subject, content string) ([]byte, error) {
 		return nil, fmt.Errorf("marshal plaintext message: %w", err)
 	}
 
-	iv := generateBarkIV()
+	// Nine random bytes encode to 12 unpadded Base64URL characters.
+	// Bark uses those ASCII bytes directly as the GCM nonce, without decoding them.
+	const entropyBytes = 9
+	random := make([]byte, entropyBytes)
+	_, _ = rand.Read(random)
+	iv := base64.RawURLEncoding.EncodeToString(random)
+
 	ciphertext, err := encryptBytes(s.encryptionKey, iv, plaintext)
 	if err != nil {
 		return nil, fmt.Errorf("encrypt payload: %w", err)
@@ -257,16 +255,6 @@ func encryptBytes(key []byte, iv string, plaintext []byte) (string, error) {
 	combined := gcm.Seal(nil, []byte(iv), plaintext, nil)
 
 	return base64.StdEncoding.EncodeToString(combined), nil
-}
-
-func generateBarkIV() string {
-	// Nine random bytes encode to 12 unpadded Base64URL characters.
-	// Bark uses those ASCII bytes directly as the GCM nonce, without decoding them.
-	const entropyBytes = 9
-	random := make([]byte, entropyBytes)
-	_, _ = rand.Read(random)
-
-	return base64.RawURLEncoding.EncodeToString(random)
 }
 
 // Send takes a message subject and a message content and sends them to bark application.

--- a/service/bark/bark.go
+++ b/service/bark/bark.go
@@ -3,6 +3,10 @@ package bark
 import (
 	"bytes"
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,13 +14,21 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode"
+)
+
+const (
+	aesKeyLen128 = 16
+	aesKeyLen192 = 24
+	aesKeyLen256 = 32
 )
 
 // Service allow you to configure Bark service.
 type Service struct {
-	deviceKey  string
-	client     *http.Client
-	serverURLs []string
+	deviceKey     string
+	client        *http.Client
+	serverURLs    []string
+	encryptionKey []byte
 }
 
 func defaultHTTPClient() *http.Client {
@@ -83,16 +95,68 @@ func New(deviceKey string) *Service {
 	return NewWithServers(deviceKey)
 }
 
-// postData is the data to send to the bark server.
+// SetEncryptionKey configures AES-GCM encryption for notifications.
+// The key must be a raw ASCII string of 16, 24, or 32 characters, matching the
+// key configured in the Bark app. Each encrypted request carries a fresh
+// 12-character IV, overriding the app's saved IV. An empty key disables encryption.
+// An invalid key leaves the previous configuration unchanged.
+// Call SetEncryptionKey before Send; it must not run concurrently with Send
+// or another call to SetEncryptionKey.
+func (s *Service) SetEncryptionKey(key string) error {
+	if key == "" {
+		s.encryptionKey = nil
+		return nil
+	}
+
+	if !isASCII(key) {
+		return errors.New("bark encryption key must contain only ASCII characters")
+	}
+
+	switch len(key) {
+	case aesKeyLen128, aesKeyLen192, aesKeyLen256:
+	default:
+		return errors.New("bark encryption key must contain exactly 16, 24, or 32 ASCII characters")
+	}
+
+	s.encryptionKey = []byte(key)
+
+	return nil
+}
+
+func isASCII(value string) bool {
+	for _, r := range value {
+		if r > unicode.MaxASCII {
+			return false
+		}
+	}
+
+	return true
+}
+
+// notificationParams is the Bark parameter object encrypted inside ciphertext.
+// device_key stays on the outer request.
+type notificationParams struct {
+	Title string `json:"title"`
+	Body  string `json:"body,omitempty"`
+	Badge int    `json:"badge,omitzero"`
+	Sound string `json:"sound,omitempty"`
+	Icon  string `json:"icon,omitempty"`
+	Group string `json:"group,omitempty"`
+	URL   string `json:"pushURL,omitempty"`
+}
+
+// postData is the plaintext Bark /push request.
 type postData struct {
+	notificationParams
+
 	DeviceKey string `json:"device_key"`
-	Title     string `json:"title"`
-	Body      string `json:"body,omitempty"`
-	Badge     int    `json:"badge,omitempty"`
-	Sound     string `json:"sound,omitempty"`
-	Icon      string `json:"icon,omitempty"`
-	Group     string `json:"group,omitempty"`
-	URL       string `json:"pushURL,omitempty"`
+}
+
+// encryptedPostData is the Bark /push wire format used when AES-GCM is enabled.
+type encryptedPostData struct {
+	DeviceKey  string `json:"device_key"`
+	Ciphertext string `json:"ciphertext"`
+	IV         string `json:"iv"`
 }
 
 func (s *Service) send(ctx context.Context, serverURL, subject, content string) error {
@@ -100,17 +164,9 @@ func (s *Service) send(ctx context.Context, serverURL, subject, content string) 
 		return errors.New("server url is empty")
 	}
 
-	// Marshal the message to post
-	message := &postData{
-		DeviceKey: s.deviceKey,
-		Title:     subject,
-		Body:      content,
-		Sound:     "alarm.caf",
-	}
-
-	messageJSON, err := json.Marshal(message)
+	messageJSON, err := s.marshalRequest(subject, content)
 	if err != nil {
-		return fmt.Errorf("marshal message: %w", err)
+		return err
 	}
 
 	pushURL := serverURL + "push"
@@ -141,6 +197,76 @@ func (s *Service) send(ctx context.Context, serverURL, subject, content string) 
 	}
 
 	return nil
+}
+
+func (s *Service) marshalRequest(subject, content string) ([]byte, error) {
+	params := notificationParams{
+		Title: subject,
+		Body:  content,
+		Sound: "alarm.caf",
+	}
+
+	if len(s.encryptionKey) == 0 {
+		messageJSON, err := json.Marshal(&postData{
+			DeviceKey:          s.deviceKey,
+			notificationParams: params,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("marshal message: %w", err)
+		}
+
+		return messageJSON, nil
+	}
+
+	plaintext, err := json.Marshal(&params)
+	if err != nil {
+		return nil, fmt.Errorf("marshal plaintext message: %w", err)
+	}
+
+	iv := generateBarkIV()
+	ciphertext, err := encryptBytes(s.encryptionKey, iv, plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt payload: %w", err)
+	}
+
+	encrypted := &encryptedPostData{
+		DeviceKey:  s.deviceKey,
+		Ciphertext: ciphertext,
+		IV:         iv,
+	}
+
+	messageJSON, err := json.Marshal(encrypted)
+	if err != nil {
+		return nil, fmt.Errorf("marshal encrypted message: %w", err)
+	}
+
+	return messageJSON, nil
+}
+
+func encryptBytes(key []byte, iv string, plaintext []byte) (string, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("create AES cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("create AES-GCM cipher: %w", err)
+	}
+
+	combined := gcm.Seal(nil, []byte(iv), plaintext, nil)
+
+	return base64.StdEncoding.EncodeToString(combined), nil
+}
+
+func generateBarkIV() string {
+	// Nine random bytes encode to 12 unpadded Base64URL characters.
+	// Bark uses those ASCII bytes directly as the GCM nonce, without decoding them.
+	const entropyBytes = 9
+	random := make([]byte, entropyBytes)
+	_, _ = rand.Read(random)
+
+	return base64.RawURLEncoding.EncodeToString(random)
 }
 
 // Send takes a message subject and a message content and sends them to bark application.

--- a/service/bark/bark_test.go
+++ b/service/bark/bark_test.go
@@ -247,13 +247,6 @@ func TestSendEncryptionFailurePreventsNetworkIO(t *testing.T) {
 	assert.NotContains(t, err.Error(), "private body")
 }
 
-func TestGenerateBarkIV(t *testing.T) {
-	t.Parallel()
-
-	iv := generateBarkIV()
-	assert.Regexp(t, `^[A-Za-z0-9_-]{12}$`, iv)
-}
-
 func captureEncryptedRequest(t *testing.T, got chan<- encryptedPostData) http.HandlerFunc {
 	t.Helper()
 

--- a/service/bark/bark_test.go
+++ b/service/bark/bark_test.go
@@ -212,10 +212,10 @@ func TestSendEncryptsCompletePayloadAndRotatesIV(t *testing.T) {
 	assert.NotEqual(t, requests[0].IV, requests[1].IV)
 	assert.NotEqual(t, requests[0].Ciphertext, requests[1].Ciphertext)
 
-	expectedPlaintext := notificationParams{
-		Title: title,
-		Body:  body,
-		Sound: "alarm.caf",
+	expectedPlaintext := map[string]string{
+		"title": title,
+		"body":  body,
+		"sound": "alarm.caf",
 	}
 	for _, request := range requests {
 		assert.Equal(t, deviceKey, request.DeviceKey)
@@ -268,7 +268,7 @@ func captureEncryptedRequest(t *testing.T, got chan<- encryptedPostData) http.Ha
 	}
 }
 
-func decryptPostData(t *testing.T, key string, payload encryptedPostData) notificationParams {
+func decryptPostData(t *testing.T, key string, payload encryptedPostData) map[string]string {
 	t.Helper()
 
 	block, err := aes.NewCipher([]byte(key))
@@ -281,13 +281,8 @@ func decryptPostData(t *testing.T, key string, payload encryptedPostData) notifi
 	plaintext, err := gcm.Open(nil, []byte(payload.IV), raw, nil)
 	require.NoError(t, err)
 
-	var params notificationParams
+	var params map[string]string
 	require.NoError(t, json.Unmarshal(plaintext, &params))
-
-	var envelope map[string]any
-	require.NoError(t, json.Unmarshal(plaintext, &envelope))
-	_, hasDeviceKey := envelope["device_key"]
-	assert.False(t, hasDeviceKey)
 
 	return params
 }

--- a/service/bark/bark_test.go
+++ b/service/bark/bark_test.go
@@ -1,0 +1,300 @@
+package bark
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetEncryptionKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		key     string
+		wantErr string
+	}{
+		{
+			name: "AES-128",
+			key:  strings.Repeat("k", aesKeyLen128),
+		},
+		{
+			name: "AES-192",
+			key:  strings.Repeat("k", aesKeyLen192),
+		},
+		{
+			name: "AES-256",
+			key:  strings.Repeat("k", aesKeyLen256),
+		},
+		{
+			name: "empty key disables encryption",
+			key:  "",
+		},
+		{
+			name:    "too short",
+			key:     "short",
+			wantErr: "bark encryption key must contain exactly 16, 24, or 32 ASCII characters",
+		},
+		{
+			name:    "unsupported length",
+			key:     strings.Repeat("k", 17),
+			wantErr: "bark encryption key must contain exactly 16, 24, or 32 ASCII characters",
+		},
+		{
+			name:    "non-ascii",
+			key:     strings.Repeat("锁", 16),
+			wantErr: "bark encryption key must contain only ASCII characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc := New("device-key")
+			err := svc.SetEncryptionKey(tt.key)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				assert.Empty(t, svc.encryptionKey)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.key == "" {
+				assert.Nil(t, svc.encryptionKey)
+			} else {
+				assert.Equal(t, []byte(tt.key), svc.encryptionKey)
+			}
+		})
+	}
+}
+
+func TestSetEncryptionKeyClearsPreviousKey(t *testing.T) {
+	t.Parallel()
+
+	svc := New("device-key")
+	require.NoError(t, svc.SetEncryptionKey(strings.Repeat("k", aesKeyLen256)))
+	require.NoError(t, svc.SetEncryptionKey(""))
+	assert.Empty(t, svc.encryptionKey)
+}
+
+func TestSetEncryptionKeyRejectsReplacement(t *testing.T) {
+	t.Parallel()
+
+	svc := New("device-key")
+	key := strings.Repeat("k", aesKeyLen128)
+	require.NoError(t, svc.SetEncryptionKey(key))
+	for _, invalid := range []string{"short", strings.Repeat("锁", 16)} {
+		require.Error(t, svc.SetEncryptionKey(invalid))
+		assert.Equal(t, []byte(key), svc.encryptionKey)
+	}
+}
+
+func TestEncryptBytesKnownVectors(t *testing.T) {
+	t.Parallel()
+
+	// Cross-checked with Node.js crypto.createCipheriv: UTF-8 key and IV,
+	// no AAD, then Base64(cipher.update(plaintext) + cipher.final() + cipher.getAuthTag()).
+	tests := []struct {
+		name               string
+		key                string
+		expectedCiphertext string
+	}{
+		{
+			name:               "AES-128",
+			key:                strings.Repeat("k", aesKeyLen128),
+			expectedCiphertext: "M31imDGJqdEEszZWcWfgiMTooJniyhmvnRIIrUSrWDVi3FxcD9cl1Dyre2wQ8a5I2bhFyBrGPeMEwp1+Uw==",
+		},
+		{
+			name:               "AES-192",
+			key:                strings.Repeat("k", aesKeyLen192),
+			expectedCiphertext: "QyuvztP2Yktq2khUWXw6hYrjLnhuc+kC44lyGOaVYBRJC4vsYaB6RewayvX+4ZKjUUIifRWDtIiVFq/KgA==",
+		},
+		{
+			name:               "AES-256",
+			key:                strings.Repeat("k", aesKeyLen256),
+			expectedCiphertext: "a9CkBbe9d0qkskyAzKyb4pV/WjH6D1J/JLm0EOUTMcoTpJEs10gqANkkLKaOPqVXL0yo0AaxElYjmLmynw==",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ciphertext, err := encryptBytes(
+				[]byte(tt.key),
+				"fixed-iv-123",
+				[]byte(`{"body":"Encrypted weather","level":"active"}`),
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedCiphertext, ciphertext)
+		})
+	}
+}
+
+func TestSendPlaintext(t *testing.T) {
+	t.Parallel()
+
+	var got map[string]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/push", r.URL.Path)
+		assert.Equal(t, "application/json; charset=utf-8", r.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.NoError(t, json.Unmarshal(body, &got))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	svc := NewWithServers("device-key", server.URL)
+	require.NoError(t, svc.Send(t.Context(), "Title", "Body"))
+
+	assert.Equal(t, map[string]string{
+		"device_key": "device-key",
+		"title":      "Title",
+		"body":       "Body",
+		"sound":      "alarm.caf",
+	}, got)
+}
+
+func TestSendPlaintextKeepsEmptyDeviceKey(t *testing.T) {
+	t.Parallel()
+
+	var raw []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		raw, err = io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	svc := NewWithServers("", server.URL)
+	require.NoError(t, svc.Send(t.Context(), "Title", "Body"))
+	assert.Contains(t, string(raw), `"device_key":""`)
+}
+
+func TestSendEncryptsCompletePayloadAndRotatesIV(t *testing.T) {
+	t.Parallel()
+
+	const (
+		deviceKey = "private-device"
+		title     = "Private encrypted title"
+		body      = "Private encrypted body"
+		key       = "kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk"
+	)
+
+	firstServerGot := make(chan encryptedPostData, 1)
+	secondServerGot := make(chan encryptedPostData, 1)
+
+	firstServer := httptest.NewServer(captureEncryptedRequest(t, firstServerGot))
+	t.Cleanup(firstServer.Close)
+	secondServer := httptest.NewServer(captureEncryptedRequest(t, secondServerGot))
+	t.Cleanup(secondServer.Close)
+
+	svc := NewWithServers(deviceKey, firstServer.URL, secondServer.URL)
+	require.NoError(t, svc.SetEncryptionKey(key))
+
+	require.NoError(t, svc.Send(t.Context(), title, body))
+
+	requests := []encryptedPostData{<-firstServerGot, <-secondServerGot}
+	assert.NotEqual(t, requests[0].IV, requests[1].IV)
+	assert.NotEqual(t, requests[0].Ciphertext, requests[1].Ciphertext)
+
+	expectedPlaintext := notificationParams{
+		Title: title,
+		Body:  body,
+		Sound: "alarm.caf",
+	}
+	for _, request := range requests {
+		assert.Equal(t, deviceKey, request.DeviceKey)
+		assert.Regexp(t, `^[A-Za-z0-9_-]{12}$`, request.IV)
+		assert.Equal(t, expectedPlaintext, decryptPostData(t, key, request))
+	}
+}
+
+func TestSendEncryptionFailurePreventsNetworkIO(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	svc := NewWithServers("private-device", server.URL)
+	svc.encryptionKey = []byte("invalid")
+
+	err := svc.Send(t.Context(), "private title", "private body")
+	require.Error(t, err)
+	assert.False(t, called)
+	var keySizeError aes.KeySizeError
+	require.ErrorAs(t, err, &keySizeError)
+	assert.Contains(t, err.Error(), "encrypt payload: create AES cipher")
+	assert.NotContains(t, err.Error(), "private title")
+	assert.NotContains(t, err.Error(), "private body")
+}
+
+func TestGenerateBarkIV(t *testing.T) {
+	t.Parallel()
+
+	iv := generateBarkIV()
+	assert.Regexp(t, `^[A-Za-z0-9_-]{12}$`, iv)
+}
+
+func captureEncryptedRequest(t *testing.T, got chan<- encryptedPostData) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+
+		var payload encryptedPostData
+		assert.NoError(t, json.Unmarshal(raw, &payload))
+		var envelope map[string]string
+		assert.NoError(t, json.Unmarshal(raw, &envelope))
+		assert.Equal(t, map[string]string{
+			"device_key": payload.DeviceKey,
+			"ciphertext": payload.Ciphertext,
+			"iv":         payload.IV,
+		}, envelope)
+		got <- payload
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func decryptPostData(t *testing.T, key string, payload encryptedPostData) notificationParams {
+	t.Helper()
+
+	block, err := aes.NewCipher([]byte(key))
+	require.NoError(t, err)
+	gcm, err := cipher.NewGCM(block)
+	require.NoError(t, err)
+
+	raw, err := base64.StdEncoding.DecodeString(payload.Ciphertext)
+	require.NoError(t, err)
+	plaintext, err := gcm.Open(nil, []byte(payload.IV), raw, nil)
+	require.NoError(t, err)
+
+	var params notificationParams
+	require.NoError(t, json.Unmarshal(plaintext, &params))
+
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(plaintext, &envelope))
+	_, hasDeviceKey := envelope["device_key"]
+	assert.False(t, hasDeviceKey)
+
+	return params
+}

--- a/service/bark/doc.go
+++ b/service/bark/doc.go
@@ -21,6 +21,11 @@ Usage:
 	    // Or use `bark.New` to create a service with the default server.
 	    barkService = bark.New("your bark device key")
 
+	    // Optional: use the encryption key configured in the Bark app.
+	    if err := barkService.SetEncryptionKey("1234567890123456"); err != nil {
+	        log.Fatal(err)
+	    }
+
 	    // Tell our notifier to use the bark service.
 	    notify.UseServices(barkService)
 


### PR DESCRIPTION
## Description

Add optional AES-GCM encryption to the Bark service.

Call `SetEncryptionKey` with the same 16-, 24-, or 32-character ASCII key configured in the Bark app. Subsequent notifications encrypt the complete parameter object and POST `device_key`, `ciphertext`, and `iv` to `/push`. The IV is a fresh 12-character Bark-compatible nonce for every request. An empty key keeps the existing plaintext path.

This matches the Bark app AES-GCM wire format used by [apprise#1684](https://github.com/caronc/apprise/pull/1684).

## Motivation and Context

AES-GCM keeps the notification title and body private. Transit hops and a third-party Bark server only see ciphertext, so callers do not have to run and operate their own Bark server just to keep message content off someone else's disk.

Without a key, the service still sends plaintext, so existing callers are unchanged.

## How Has This Been Tested?

- `go test -count=1 -race ./service/bark/`
- `golangci-lint run --timeout=5m ./...` (v2.12.2, 0 issues)
- Interoperability vectors from Apprise for AES-128/192/256 with a fixed IV
- Coverage for invalid keys, IV rotation across servers, fail-closed encryption errors, and plaintext regression

## Screenshots / Output (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
